### PR TITLE
Updated api_handlers.go, database.go, and utils.go

### DIFF
--- a/occupi-backend/pkg/handlers/api_handlers.go
+++ b/occupi-backend/pkg/handlers/api_handlers.go
@@ -49,7 +49,7 @@ func BookRoom(ctx *gin.Context, appsession *models.AppSession) {
 
 	// Generate a unique ID for the booking
 	booking.ID = primitive.NewObjectID().Hex()
-	booking.OccupiID = 1
+	booking.OccupiID = utils.GenerateOccupiBookID()
 	booking.CheckedIn = false
 
 	// Save the booking to the database

--- a/occupi-backend/pkg/models/database.go
+++ b/occupi-backend/pkg/models/database.go
@@ -17,7 +17,7 @@ type User struct {
 // structure of booking
 type Booking struct {
 	ID        string   `json:"_id" bson:"_id,omitempty"`
-	OccupiID  int      `json:"occupiId" bson:"occupiId,omitempty"`
+	OccupiID  string   `json:"occupiId" bson:"occupiId,omitempty"`
 	RoomID    string   `json:"roomId" bson:"roomId"`
 	Slot      int      `json:"slot" bson:"slot"`
 	Emails    []string `json:"emails" bson:"emails"`

--- a/occupi-backend/pkg/utils/utils.go
+++ b/occupi-backend/pkg/utils/utils.go
@@ -64,6 +64,17 @@ func GenerateEmployeeID() string {
 	return employeeID
 }
 
+// Function to generate a Booking ID with the structure BOOKYYYYMMDDXXXX
+func GenerateOccupiBookID() string {
+	currentYear := time.Now().Year()
+	randomNum, err := generateRandomNumber()
+	if err != nil {
+		return "BOOK00000000"
+	}
+	BookID := fmt.Sprintf("BOOK%d%04d", currentYear, randomNum)
+	return BookID
+}
+
 // generates a random auth0 state
 func GenerateRandomState() (string, error) {
 	b := make([]byte, 32)


### PR DESCRIPTION
# Description
OccupiID for booking is now generated instead of it being 1

Fixes # (issue)

## Type of change
Updated utils.go, api_handlers.go, databse.go
Please delete options that are not relevant.

- [ ] OccupiID generation for booking (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
