### PR TITLE
feat: Add cache package for user and OTP caching

### DIFF
--- a/occupi-backend/pkg/cache/cache.go
+++ b/occupi-backend/pkg/cache/cache.go
@@ -30,39 +30,35 @@ func GetUser(appsession *models.AppSession, email string) (models.User, error) {
 	return user, nil
 }
 
-func SetUser(appsession *models.AppSession, user models.User) error {
+func SetUser(appsession *models.AppSession, user models.User) {
 	if appsession.Cache == nil {
-		return errors.New("cache not found")
+		return
 	}
 
 	// marshal the user
 	userData, err := bson.Marshal(user)
 	if err != nil {
 		logrus.Error("failed to marshall", err)
-		return err
+		return
 	}
 
 	// set the user in the cache
 	if err := appsession.Cache.Set(user.Email, userData); err != nil {
 		logrus.Error("failed to set user in cache", err)
-		return err
+		return
 	}
-
-	return nil
 }
 
-func DeleteUser(appsession *models.AppSession, email string) error {
+func DeleteUser(appsession *models.AppSession, email string) {
 	if appsession.Cache == nil {
-		return errors.New("cache not found")
+		return
 	}
 
 	// delete the user from the cache
 	if err := appsession.Cache.Delete(email); err != nil {
 		logrus.Error("failed to delete user from cache", err)
-		return err
+		return
 	}
-
-	return nil
 }
 
 func GetOTP(appsession *models.AppSession, email string, otp string) (models.OTP, error) {
@@ -88,9 +84,9 @@ func GetOTP(appsession *models.AppSession, email string, otp string) (models.OTP
 	return otpData, nil
 }
 
-func SetOTP(appsession *models.AppSession, otpData models.OTP) error {
+func SetOTP(appsession *models.AppSession, otpData models.OTP) {
 	if appsession.Cache == nil {
-		return errors.New("cache not found")
+		return
 	}
 
 	// marshal the otp
@@ -98,29 +94,25 @@ func SetOTP(appsession *models.AppSession, otpData models.OTP) error {
 	otpDataBytes, err := bson.Marshal(otpData)
 	if err != nil {
 		logrus.Error("failed to marshall", err)
-		return err
+		return
 	}
 
 	// set the otp in the cache
 	if err := appsession.Cache.Set(otpKey, otpDataBytes); err != nil {
 		logrus.Error("failed to set otp in cache", err)
-		return err
+		return
 	}
-
-	return nil
 }
 
-func DeleteOTP(appsession *models.AppSession, email string, otp string) error {
+func DeleteOTP(appsession *models.AppSession, email string, otp string) {
 	if appsession.Cache == nil {
-		return errors.New("cache not found")
+		return
 	}
 
 	// delete the otp from the cache
 	otpKey := email + otp
 	if err := appsession.Cache.Delete(otpKey); err != nil {
 		logrus.Error("failed to delete otp from cache", err)
-		return err
+		return
 	}
-
-	return nil
 }

--- a/occupi-backend/pkg/cache/cache.go
+++ b/occupi-backend/pkg/cache/cache.go
@@ -1,0 +1,126 @@
+package cache
+
+import (
+	"errors"
+
+	"github.com/COS301-SE-2024/occupi/occupi-backend/pkg/models"
+	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func GetUser(appsession *models.AppSession, email string) (models.User, error) {
+	if appsession.Cache == nil {
+		return models.User{}, errors.New("cache not found")
+	}
+
+	// unmarshal the user from the cache
+	var user models.User
+	userData, err := appsession.Cache.Get(email)
+
+	if err != nil {
+		logrus.Error("key does not exist: ", err)
+		return models.User{}, err
+	}
+
+	if err := bson.Unmarshal(userData, &user); err != nil {
+		logrus.Error("failed to unmarshall", err)
+		return models.User{}, err
+	}
+
+	return user, nil
+}
+
+func SetUser(appsession *models.AppSession, user models.User) error {
+	if appsession.Cache == nil {
+		return errors.New("cache not found")
+	}
+
+	// marshal the user
+	userData, err := bson.Marshal(user)
+	if err != nil {
+		logrus.Error("failed to marshall", err)
+		return err
+	}
+
+	// set the user in the cache
+	if err := appsession.Cache.Set(user.Email, userData); err != nil {
+		logrus.Error("failed to set user in cache", err)
+		return err
+	}
+
+	return nil
+}
+
+func DeleteUser(appsession *models.AppSession, email string) error {
+	if appsession.Cache == nil {
+		return errors.New("cache not found")
+	}
+
+	// delete the user from the cache
+	if err := appsession.Cache.Delete(email); err != nil {
+		logrus.Error("failed to delete user from cache", err)
+		return err
+	}
+
+	return nil
+}
+
+func GetOTP(appsession *models.AppSession, email string, otp string) (models.OTP, error) {
+	if appsession.Cache == nil {
+		return models.OTP{}, errors.New("cache not found")
+	}
+
+	// unmarshal the otp from the cache
+	var otpData models.OTP
+	otpKey := email + otp
+	otpDataBytes, err := appsession.Cache.Get(otpKey)
+
+	if err != nil {
+		logrus.Error("key does not exist: ", err)
+		return models.OTP{}, err
+	}
+
+	if err := bson.Unmarshal(otpDataBytes, &otpData); err != nil {
+		logrus.Error("failed to unmarshall", err)
+		return models.OTP{}, err
+	}
+
+	return otpData, nil
+}
+
+func SetOTP(appsession *models.AppSession, otpData models.OTP) error {
+	if appsession.Cache == nil {
+		return errors.New("cache not found")
+	}
+
+	// marshal the otp
+	otpKey := otpData.Email + otpData.OTP
+	otpDataBytes, err := bson.Marshal(otpData)
+	if err != nil {
+		logrus.Error("failed to marshall", err)
+		return err
+	}
+
+	// set the otp in the cache
+	if err := appsession.Cache.Set(otpKey, otpDataBytes); err != nil {
+		logrus.Error("failed to set otp in cache", err)
+		return err
+	}
+
+	return nil
+}
+
+func DeleteOTP(appsession *models.AppSession, email string, otp string) error {
+	if appsession.Cache == nil {
+		return errors.New("cache not found")
+	}
+
+	// delete the otp from the cache
+	otpKey := email + otp
+	if err := appsession.Cache.Delete(otpKey); err != nil {
+		logrus.Error("failed to delete otp from cache", err)
+		return err
+	}
+
+	return nil
+}

--- a/occupi-backend/tests/cache_methods_unit_test.go
+++ b/occupi-backend/tests/cache_methods_unit_test.go
@@ -1,0 +1,371 @@
+package tests
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/COS301-SE-2024/occupi/occupi-backend/configs"
+	"github.com/COS301-SE-2024/occupi/occupi-backend/pkg/cache"
+	"github.com/COS301-SE-2024/occupi/occupi-backend/pkg/models"
+)
+
+func TestGetUser(t *testing.T) {
+	email := "test@example.com"
+	user := models.User{Email: email}
+	userData, _ := bson.Marshal(user)
+
+	tests := []struct {
+		name         string
+		email        string
+		expectedUser models.User
+		expectedErr  error
+	}{
+		{
+			name:         "cache is nil",
+			email:        email,
+			expectedUser: models.User{},
+			expectedErr:  errors.New("cache not found"),
+		},
+		{
+			name:         "cache key does not exist",
+			email:        "test1@example.com",
+			expectedUser: models.User{},
+			expectedErr:  errors.New("Entry not found"),
+		},
+		{
+			name:         "successful get user from cache",
+			email:        email,
+			expectedUser: user,
+			expectedErr:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var appsession *models.AppSession
+
+			// add user to cache
+			if tt.name != "cache is nil" {
+				appsession = &models.AppSession{
+					Cache: configs.CreateCache(),
+				}
+				err := appsession.Cache.Set(email, userData)
+
+				assert.NoError(t, err)
+			} else {
+				appsession = &models.AppSession{}
+			}
+
+			result, err := cache.GetUser(appsession, tt.email)
+
+			assert.Equal(t, tt.expectedUser, result)
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetUser(t *testing.T) {
+	email := "test@example.com"
+	user := models.User{Email: email}
+
+	tests := []struct {
+		name         string
+		user         models.User
+		expectedUser models.User
+		expectedErr  error
+	}{
+		{
+			name:         "cache is nil",
+			user:         user,
+			expectedUser: models.User{},
+			expectedErr:  errors.New("cache not found"),
+		},
+		{
+			name:         "successful set user in cache",
+			user:         user,
+			expectedUser: user,
+			expectedErr:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var appsession *models.AppSession
+
+			if tt.name != "cache is nil" {
+				appsession = &models.AppSession{
+					Cache: configs.CreateCache(),
+				}
+			} else {
+				appsession = &models.AppSession{}
+			}
+
+			err := cache.SetUser(appsession, tt.user)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+
+				// check if user was set in cache
+				userData, err := appsession.Cache.Get(email)
+				assert.NoError(t, err)
+
+				// unmarshal the user from the cache
+				var user models.User
+				if err := bson.Unmarshal(userData, &user); err != nil {
+					t.Error("failed to unmarshall", err)
+				}
+
+				assert.Equal(t, tt.expectedUser, user)
+			}
+		})
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	email := "test@example.com"
+	user := models.User{Email: email}
+
+	tests := []struct {
+		name         string
+		email        string
+		expectedUser models.User
+		expectedErr  error
+	}{
+		{
+			name:         "cache is nil",
+			email:        email,
+			expectedUser: models.User{},
+			expectedErr:  errors.New("cache not found"),
+		},
+		{
+			name:         "successful delete user in cache",
+			email:        email,
+			expectedUser: models.User{},
+			expectedErr:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var appsession *models.AppSession
+
+			if tt.name != "cache is nil" {
+				appsession = &models.AppSession{
+					Cache: configs.CreateCache(),
+				}
+
+				// add user to cache
+				userData, _ := bson.Marshal(user)
+				err := appsession.Cache.Set(email, userData)
+
+				assert.NoError(t, err)
+			} else {
+				appsession = &models.AppSession{}
+			}
+
+			err := cache.DeleteUser(appsession, tt.email)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+
+				// check if user was deleted in cache
+				userData, err := appsession.Cache.Get(email)
+				assert.NotNil(t, err)
+				assert.Nil(t, userData)
+			}
+		})
+	}
+}
+
+func TestGetOTP(t *testing.T) {
+	email := "test@example.com"
+	otpv := "123456"
+	otp := models.OTP{Email: email, OTP: otpv}
+	otpData, _ := bson.Marshal(otp)
+
+	tests := []struct {
+		name        string
+		email       string
+		expectedOTP models.OTP
+		expectedErr error
+	}{
+		{
+			name:        "cache is nil",
+			email:       email,
+			expectedOTP: models.OTP{},
+			expectedErr: errors.New("cache not found"),
+		},
+		{
+			name:        "cache key does not exist",
+			email:       "test1@example.com",
+			expectedOTP: models.OTP{},
+			expectedErr: errors.New("Entry not found"),
+		},
+		{
+			name:        "successful get otp from cache",
+			email:       email,
+			expectedOTP: otp,
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var appsession *models.AppSession
+
+			// add otp to cache
+			if tt.name != "cache is nil" {
+				appsession = &models.AppSession{
+					Cache: configs.CreateCache(),
+				}
+				err := appsession.Cache.Set(email+otpv, otpData)
+
+				assert.NoError(t, err)
+			} else {
+				appsession = &models.AppSession{}
+			}
+
+			result, err := cache.GetOTP(appsession, tt.email, otpv)
+
+			assert.Equal(t, tt.expectedOTP, result)
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetOTP(t *testing.T) {
+	email := "test@example.com"
+	otpv := "123456"
+	otp := models.OTP{Email: email, OTP: otpv}
+
+	tests := []struct {
+		name        string
+		otp         models.OTP
+		expectedOTP models.OTP
+		expectedErr error
+	}{
+		{
+			name:        "cache is nil",
+			otp:         otp,
+			expectedOTP: models.OTP{},
+			expectedErr: errors.New("cache not found"),
+		},
+		{
+			name: "successful set otp in cache",
+			otp:  otp,
+			expectedOTP: models.OTP{
+				Email: email,
+				OTP:   otpv,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var appsession *models.AppSession
+
+			if tt.name != "cache is nil" {
+				appsession = &models.AppSession{
+					Cache: configs.CreateCache(),
+				}
+			} else {
+				appsession = &models.AppSession{}
+			}
+
+			err := cache.SetOTP(appsession, tt.otp)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+
+				// check if otp was set in cache
+				otpData, err := appsession.Cache.Get(email + otpv)
+				assert.NoError(t, err)
+
+				// unmarshal the otp from the cache
+				var otp models.OTP
+				if err := bson.Unmarshal(otpData, &otp); err != nil {
+					t.Error("failed to unmarshall", err)
+				}
+
+				assert.Equal(t, tt.expectedOTP, otp)
+			}
+		})
+	}
+}
+
+func TestDeleteOTPF(t *testing.T) {
+	email := "test@example.com"
+	otpv := "123456"
+	otp := models.OTP{Email: email, OTP: otpv}
+
+	tests := []struct {
+		name        string
+		expectedOTP models.OTP
+		expectedErr error
+	}{
+		{
+			name:        "cache is nil",
+			expectedOTP: models.OTP{},
+			expectedErr: errors.New("cache not found"),
+		},
+		{
+			name: "successful delete otp in cache",
+			expectedOTP: models.OTP{
+				Email: email,
+				OTP:   otpv,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var appsession *models.AppSession
+
+			if tt.name != "cache is nil" {
+				appsession = &models.AppSession{
+					Cache: configs.CreateCache(),
+				}
+
+				// add otp to cache
+				otpData, _ := bson.Marshal(otp)
+				err := appsession.Cache.Set(email+otpv, otpData)
+
+				assert.NoError(t, err)
+			} else {
+				appsession = &models.AppSession{}
+			}
+
+			err := cache.DeleteOTP(appsession, tt.expectedOTP.Email, tt.expectedOTP.OTP)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+
+				// check if otp was deleted in cache
+				otpData, err := appsession.Cache.Get(email + otpv)
+				assert.NotNil(t, err)
+				assert.Nil(t, otpData)
+			}
+		})
+	}
+}

--- a/occupi-backend/tests/cache_methods_unit_test.go
+++ b/occupi-backend/tests/cache_methods_unit_test.go
@@ -79,19 +79,16 @@ func TestSetUser(t *testing.T) {
 		name         string
 		user         models.User
 		expectedUser models.User
-		expectedErr  error
 	}{
 		{
 			name:         "cache is nil",
 			user:         user,
 			expectedUser: models.User{},
-			expectedErr:  errors.New("cache not found"),
 		},
 		{
 			name:         "successful set user in cache",
 			user:         user,
 			expectedUser: user,
-			expectedErr:  nil,
 		},
 	}
 
@@ -107,12 +104,9 @@ func TestSetUser(t *testing.T) {
 				appsession = &models.AppSession{}
 			}
 
-			err := cache.SetUser(appsession, tt.user)
+			cache.SetUser(appsession, tt.user)
 
-			if tt.expectedErr != nil {
-				assert.EqualError(t, err, tt.expectedErr.Error())
-			} else {
-				assert.NoError(t, err)
+			if tt.name != "cache is nil" {
 
 				// check if user was set in cache
 				userData, err := appsession.Cache.Get(email)
@@ -138,19 +132,16 @@ func TestDeleteUser(t *testing.T) {
 		name         string
 		email        string
 		expectedUser models.User
-		expectedErr  error
 	}{
 		{
 			name:         "cache is nil",
 			email:        email,
 			expectedUser: models.User{},
-			expectedErr:  errors.New("cache not found"),
 		},
 		{
 			name:         "successful delete user in cache",
 			email:        email,
 			expectedUser: models.User{},
-			expectedErr:  nil,
 		},
 	}
 
@@ -172,12 +163,9 @@ func TestDeleteUser(t *testing.T) {
 				appsession = &models.AppSession{}
 			}
 
-			err := cache.DeleteUser(appsession, tt.email)
+			cache.DeleteUser(appsession, tt.email)
 
-			if tt.expectedErr != nil {
-				assert.EqualError(t, err, tt.expectedErr.Error())
-			} else {
-				assert.NoError(t, err)
+			if tt.name != "cache is nil" {
 
 				// check if user was deleted in cache
 				userData, err := appsession.Cache.Get(email)
@@ -257,13 +245,11 @@ func TestSetOTP(t *testing.T) {
 		name        string
 		otp         models.OTP
 		expectedOTP models.OTP
-		expectedErr error
 	}{
 		{
 			name:        "cache is nil",
 			otp:         otp,
 			expectedOTP: models.OTP{},
-			expectedErr: errors.New("cache not found"),
 		},
 		{
 			name: "successful set otp in cache",
@@ -272,7 +258,6 @@ func TestSetOTP(t *testing.T) {
 				Email: email,
 				OTP:   otpv,
 			},
-			expectedErr: nil,
 		},
 	}
 
@@ -288,13 +273,9 @@ func TestSetOTP(t *testing.T) {
 				appsession = &models.AppSession{}
 			}
 
-			err := cache.SetOTP(appsession, tt.otp)
+			cache.SetOTP(appsession, tt.otp)
 
-			if tt.expectedErr != nil {
-				assert.EqualError(t, err, tt.expectedErr.Error())
-			} else {
-				assert.NoError(t, err)
-
+			if tt.name != "cache is nil" {
 				// check if otp was set in cache
 				otpData, err := appsession.Cache.Get(email + otpv)
 				assert.NoError(t, err)
@@ -319,12 +300,10 @@ func TestDeleteOTPF(t *testing.T) {
 	tests := []struct {
 		name        string
 		expectedOTP models.OTP
-		expectedErr error
 	}{
 		{
 			name:        "cache is nil",
 			expectedOTP: models.OTP{},
-			expectedErr: errors.New("cache not found"),
 		},
 		{
 			name: "successful delete otp in cache",
@@ -332,7 +311,6 @@ func TestDeleteOTPF(t *testing.T) {
 				Email: email,
 				OTP:   otpv,
 			},
-			expectedErr: nil,
 		},
 	}
 
@@ -354,13 +332,9 @@ func TestDeleteOTPF(t *testing.T) {
 				appsession = &models.AppSession{}
 			}
 
-			err := cache.DeleteOTP(appsession, tt.expectedOTP.Email, tt.expectedOTP.OTP)
+			cache.DeleteOTP(appsession, tt.expectedOTP.Email, tt.expectedOTP.OTP)
 
-			if tt.expectedErr != nil {
-				assert.EqualError(t, err, tt.expectedErr.Error())
-			} else {
-				assert.NoError(t, err)
-
+			if tt.name != "cache is nil" {
 				// check if otp was deleted in cache
 				otpData, err := appsession.Cache.Get(email + otpv)
 				assert.NotNil(t, err)


### PR DESCRIPTION
# Description

This commit adds a new package called `cache` which provides functions for caching user and OTP data. It includes functions for getting, setting, and deleting user and OTP data from the cache. This will improve performance by reducing database queries for frequently accessed data.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added some unit tests for the cache

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
